### PR TITLE
Match exported value name implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,73 @@ A rule to enforce a certain file naming convention.
 
 The convention can be configured using a regular expression (the default is `camelCase.js`):
 
-```
+```js
 "filenames/filenames": [2, "^[a-z_]+$"]
 ```
+
+An extra option can be set to check the file name against the default exported value in the module.
+By default, the exported value is ignored.
+
+#### `"match-regex-and-exported"` or `"match-exported-and-regex"`
+
+The file name must match the regular expression and the exported value name, if any. Example:
+
+```js
+"filenames/filenames": [2, "^[a-z_]+$", "match-regex-and-exported"]
+```
+
+```js
+// Considered problem only if the file isn't named foo.js
+export default function foo() {}
+
+// Always considered problem, since the exported value doesn't match the regular expression
+// (conflicting options)
+module.exports = class Foo {};
+
+// Considered problem only if the file doen't match the regular expression
+export default { foo: "bar" };
+```
+
+#### `"match-exported-or-regex"`
+
+The file name must match the exported value name, if any. Else it should match the regular
+expression.
+
+```js
+"filenames/filenames": [2, "^[a-z_]+$", "match-exported-or-regex"]
+```
+
+```js
+// Considered problem only if the file isn't named foo.js
+export default foo {}
+
+// Considered problem only if the file isn't named Foo.js
+module.exports = class Foo {};
+
+// Considered problem only if the file doesn't match the regular expression
+export default { foo: "bar" };
+```
+
+#### `"match-regex-or-exported"`
+
+The file name must match the regular expression. Else it should match the exported value name, if
+any.
+
+```js
+"filenames/filenames": [2, "^[a-z_]+$", "match-regex-or-exported"]
+```
+
+```js
+// Considered problem only if the file doesn't match the regular expression or isn't named foo.js
+export default foo {}
+
+// Considered problem only if the file doesn't match the regular expression or isn't named Foo.js
+module.exports = class Foo {};
+
+// Considered problem only if the file doesn't match the regular expression
+export default { foo: "bar" };
+```
+
 
 ## Changelog
 

--- a/lib/rules/filenames.js
+++ b/lib/rules/filenames.js
@@ -88,11 +88,11 @@ module.exports = function(context) {
                 reportIf(!matchesRegex && !matchesExported, "Filename '{{name}}' does not match the naming convention nor exported value '{{exportName}}'.");
             }
             else if (flag === "match-exported-or-regex") {
-                reportIf(!matchesExported, "File '{{name}}' must be named '{{exportName}}{{extension}}'.");
+                reportIf(!matchesExported, "File '{{name}}' must be named '{{exportName}}{{extension}}', after its exported value.");
             }
             else { // Match both, flag === "match-exported-and-regex" || flag === "match-regex-and-exported"
                 reportIf(!matchesRegex, "Filename '{{name}}' does not match the naming convention.");
-                reportIf(!matchesExported, "File '{{name}}' must be named '{{exportName}}{{extension}}'.");
+                reportIf(!matchesExported, "File '{{name}}' must be named '{{exportName}}{{extension}}', after its exported value.");
             }
         }
     };

--- a/lib/rules/filenames.js
+++ b/lib/rules/filenames.js
@@ -15,18 +15,44 @@ module.exports = function(context) {
     "use strict";
 
     var defaultRegexp = /^([a-z0-9]+)([A-Z][a-z0-9]+)*$/g,
-        conventionRegexp = context.options[0] ? new RegExp(context.options[0]) : defaultRegexp;
+        conventionRegexp = context.options[0] ? new RegExp(context.options[0]) : defaultRegexp,
+        flag = context.options[1] || "match-regex";
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
-    function matchesConvention(filenameWithoutExtension) {
-        return conventionRegexp.test(filenameWithoutExtension);
+    function getNodeName(node) {
+        if (node.type === "Identifier") {
+            return node.name;
+        }
+
+        if (node.id && node.id.type === "Identifier") {
+            return node.id.name;
+        }
     }
 
-    function report(node, filename) {
-        context.report(node, "Filename '{{name}}' does not match the naming convention.", { name: filename });
+    function getExportedName(programNode) {
+        for (var i = 0; i < programNode.body.length; i += 1) {
+            var node = programNode.body[i];
+
+            // export default ...
+            if (node.type === "ExportDefaultDeclaration") {
+                return getNodeName(node.declaration);
+            }
+
+            // module.exports = ...
+            if (node.type === "ExpressionStatement" &&
+                node.expression.type === "AssignmentExpression" &&
+                node.expression.left.type === "MemberExpression" &&
+                node.expression.left.object.type === "Identifier" &&
+                node.expression.left.object.name === "module" &&
+                node.expression.left.property.type === "Identifier" &&
+                node.expression.left.property.name === "exports"
+            ) {
+                return getNodeName(node.expression.right);
+            }
+        }
     }
 
     return {
@@ -34,10 +60,39 @@ module.exports = function(context) {
             var filename = context.getFilename(),
                 extension = path.extname(filename),
                 isFromStdin = ignoredFilenames.indexOf(filename) !== -1,
-                filenameWithoutExtension = path.basename(filename, extension);
+                filenameWithoutExtension = path.basename(filename, extension),
+                exportedName = getExportedName(node);
 
-            if (!isFromStdin && !matchesConvention(filenameWithoutExtension)) {
-                report(node, filename);
+            if (isFromStdin) return;
+
+            var matchesRegex = conventionRegexp.test(filenameWithoutExtension);
+
+            var isExporting = Boolean(exportedName);
+            var matchesExported = filenameWithoutExtension === exportedName;
+
+            var reportIf = function (condition, message) {
+                if (condition) {
+                    context.report(node, message, {
+                        name: filename,
+                        exportName: exportedName,
+                        extension: extension,
+                        flag: flag
+                    });
+                }
+            };
+
+            if (flag === "match-regex" || !isExporting) {
+                reportIf(!matchesRegex, "Filename '{{name}}' does not match the naming convention.");
+            }
+            else if (flag === "match-regex-or-exported") {
+                reportIf(!matchesRegex && !matchesExported, "Filename '{{name}}' does not match the naming convention nor exported value '{{exportName}}'.");
+            }
+            else if (flag === "match-exported-or-regex") {
+                reportIf(!matchesExported, "File '{{name}}' must be named '{{exportName}}{{extension}}'.");
+            }
+            else { // Match both, flag === "match-exported-and-regex" || flag === "match-regex-and-exported"
+                reportIf(!matchesRegex, "Filename '{{name}}' does not match the naming convention.");
+                reportIf(!matchesExported, "File '{{name}}' must be named '{{exportName}}{{extension}}'.");
             }
         }
     };

--- a/test/rules/filenames.js
+++ b/test/rules/filenames.js
@@ -144,7 +144,7 @@ eslintTester.addRuleTest("lib/rules/filenames", {
             filename: "fooBar.js",
             args: [ 1, null, "match-regex-and-exported" ],
             errors: [
-                { message: "File 'fooBar.js' must be named 'exported.js'.", column: 0, line: 0 }
+                { message: "File 'fooBar.js' must be named 'exported.js', after its exported value.", column: 0, line: 0 }
             ]
         },
         {
@@ -153,7 +153,7 @@ eslintTester.addRuleTest("lib/rules/filenames", {
             args: [ 1, "^[a-z_]$", "match-regex-and-exported" ],
             errors: [
                 { message: "Filename 'foo.js' does not match the naming convention.", column: 0, line: 0 },
-                { message: "File 'foo.js' must be named 'exported.js'.", column: 0, line: 0 }
+                { message: "File 'foo.js' must be named 'exported.js', after its exported value.", column: 0, line: 0 }
             ]
         },
         {
@@ -169,7 +169,7 @@ eslintTester.addRuleTest("lib/rules/filenames", {
             filename: "foo.js",
             args: [ 1, null, "match-exported-or-regex" ],
             errors: [
-                { message: "File 'foo.js' must be named 'exported.js'.", column: 0, line: 0 }
+                { message: "File 'foo.js' must be named 'exported.js', after its exported value.", column: 0, line: 0 }
             ]
         },
         {

--- a/test/rules/filenames.js
+++ b/test/rules/filenames.js
@@ -2,7 +2,8 @@ var linter = require("eslint").linter,
     ESLintTester = require("eslint-tester");
 
 var eslintTester = new ESLintTester(linter),
-    testCode = "var foo = 'bar';";
+    testCode = "var foo = 'bar';",
+    testExportingCode = "module.exports = exported;";
 
 eslintTester.addRuleTest("lib/rules/filenames", {
 
@@ -31,7 +32,81 @@ eslintTester.addRuleTest("lib/rules/filenames", {
             code: testCode,
             filename: "foo_bar.js",
             args: [ 1, "^[a-z_]+$" ]
-        }
+        },
+        {
+            code: testCode,
+            filename: "exported.js",
+            args: [ 1, null, "match-regex-and-exported" ]
+        },
+        {
+            code: testCode,
+            filename: "exported.js",
+            args: [ 1, null, "match-regex-or-exported" ]
+        },
+        {
+            code: testCode,
+            filename: "exported.js",
+            args: [ 1, null, "match-exported-or-regex" ]
+        },
+        {
+            code: testExportingCode,
+            filename: "exported.js",
+            args: [ 1, null, "match-regex-and-exported" ]
+        },
+        {
+            code: testExportingCode,
+            filename: "bar.js",
+            args: [ 1, null, "match-regex-or-exported" ]
+        },
+        {
+            code: testExportingCode,
+            filename: "exported.js",
+            args: [ 1, "^a$", "match-exported-or-regex" ]
+        },
+
+        // Testing exported name extraction
+        {
+            code: "module.exports = foo;",
+            filename: "foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true }
+        },
+        {
+            code: "module.exports = class Foo {};",
+            filename: "Foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true, classes: true }
+        },
+        {
+            code: "module.exports = function foo() {}",
+            filename: "foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true }
+        },
+        {
+            code: "export default foo;",
+            filename: "foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true }
+        },
+        {
+            code: "export default class Foo {}",
+            filename: "Foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true, classes: true }
+        },
+        {
+            code: "export default function foo() {}",
+            filename: "foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true }
+        },
+        {
+            code: "export default function () {}", // No exported name
+            filename: "foo.js",
+            args: [ 1, "^", "match-exported-and-regex" ],
+            ecmaFeatures: { modules: true }
+        },
     ],
 
     invalid: [
@@ -61,7 +136,48 @@ eslintTester.addRuleTest("lib/rules/filenames", {
             filename: "fooBar.js",
             args: [ 1, "^[a-z_]$" ],
             errors: [
-                { message: "Filename \'fooBar.js\' does not match the naming convention.", column: 0, line: 0 }
+                { message: "Filename 'fooBar.js' does not match the naming convention.", column: 0, line: 0 }
+            ]
+        },
+        {
+            code: testExportingCode,
+            filename: "fooBar.js",
+            args: [ 1, null, "match-regex-and-exported" ],
+            errors: [
+                { message: "File 'fooBar.js' must be named 'exported.js'.", column: 0, line: 0 }
+            ]
+        },
+        {
+            code: testExportingCode,
+            filename: "foo.js",
+            args: [ 1, "^[a-z_]$", "match-regex-and-exported" ],
+            errors: [
+                { message: "Filename 'foo.js' does not match the naming convention.", column: 0, line: 0 },
+                { message: "File 'foo.js' must be named 'exported.js'.", column: 0, line: 0 }
+            ]
+        },
+        {
+            code: testExportingCode,
+            filename: "foo.js",
+            args: [ 1, "^a$", "match-regex-or-exported" ],
+            errors: [
+                { message: "Filename 'foo.js' does not match the naming convention nor exported value 'exported'.", column: 0, line: 0 }
+            ]
+        },
+        {
+            code: testExportingCode,
+            filename: "foo.js",
+            args: [ 1, null, "match-exported-or-regex" ],
+            errors: [
+                { message: "File 'foo.js' must be named 'exported.js'.", column: 0, line: 0 }
+            ]
+        },
+        {
+            code: testCode,
+            filename: "foo.js",
+            args: [ 1, "^[a-z_]$", "match-exported-or-regex" ],
+            errors: [
+                { message: "Filename 'foo.js' does not match the naming convention.", column: 0, line: 0 }
             ]
         }
     ]


### PR DESCRIPTION
This is a first implementation of checking file names against the exported value name. I chose to implement the version described in [this comment](https://github.com/selaux/eslint-plugin-filenames/issues/3#issuecomment-156108643). Adding 3 flags makes this a bit more confusing than adding only one, and I don't think other flags than "exported-or-regex" are really usefull, but this is only my opinion, and I would be OK with this.

Anyway, let me know what you think, I can change anything if needed.