### PR TITLE
Make replacePattern not apply to directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,19 @@ Available transforms:
 '[kebab](https://www.npmjs.com/package/lodash.kebabcase)', and
 '[camel](https://www.npmjs.com/package/lodash.camelcase)'
 
-If you prefer to use suffixes for your files (e.g. `Foo.react.js` for a React component file), you can use the following configuration:
+If you prefer to use suffixes for your files (e.g. `Foo.react.js` for a React component file),
+you can use a second configuration parameter. It allows you to remove parts of a filename matching a regex pattern
+before transforming and matching against the export.
 
 ```json
-"filenames/match-exported": [2, "", "\\.react"]
+"filenames/match-exported": [2, "", "\\.react$"]
+```
+
+Now, in your code:
+
+```js
+// Considered problem only if file isn't named variableName.react.js, variableName.js or variableName/index.js
+export default function variableName;
 ```
 
 ### Don't allow index.js files (no-index)

--- a/lib/rules/match-exported.js
+++ b/lib/rules/match-exported.js
@@ -18,14 +18,14 @@ var path = require('path'),
         camel: require('lodash.camelcase')
     };
 
-function getStringToCheckAgainstExport(parsed) {
+function getStringToCheckAgainstExport(parsed, replacePattern) {
     var dirArray = parsed.dir.split(path.sep);
     var lastDirectory = dirArray[dirArray.length - 1];
 
     if (isIndexFile(parsed)) {
         return lastDirectory;
     } else {
-        return parsed.name;
+        return replacePattern ? parsed.name.replace(replacePattern, '') : parsed.name;
     }
 }
 
@@ -46,18 +46,17 @@ module.exports = function(context) {
                 shouldIgnore = isIgnoredFilename(filename),
                 exportedName = getExportedName(node),
                 isExporting = Boolean(exportedName),
-                expectedExport = getStringToCheckAgainstExport(parsed),
-                transformedExport = replacePattern ? expectedExport.replace(replacePattern, '') : expectedExport,
+                expectedExport = getStringToCheckAgainstExport(parsed, replacePattern),
                 transformedName = transform(exportedName, transformName),
                 everythingIsIndex = exportedName === 'index' && parsed.name === 'index',
-                matchesExported = transformedName === transformedExport || everythingIsIndex,
+                matchesExported = transformedName === expectedExport || everythingIsIndex,
                 reportIf = function (condition, messageForNormalFile, messageForIndexFile) {
                     var message = (!messageForIndexFile || !isIndexFile(parsed)) ? messageForNormalFile : messageForIndexFile;
 
                     if (condition) {
                         context.report(node, message, {
                             name: parsed.base,
-                            expectedExport: transformedExport,
+                            expectedExport: expectedExport,
                             exportName: transformedName,
                             extension: parsed.ext
                         });

--- a/test/rules/match-exported.js
+++ b/test/rules/match-exported.js
@@ -253,13 +253,13 @@ ruleTester.run("lib/rules/match-exported with configuration", exportedRule, {
             code: exportedJsxClassCode,
             filename: "/some/dir/Foo.react.js",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
-            options: ["", "\\.react"]
+            options: ["", "\\.react$"]
         },
         {
             code: exportedEs6JsxClassCode,
             filename: "/some/dir/Foo.react.js",
             parserOptions: { ecmaVersion: 6, sourceType: "module", ecmaFeatures: { jsx: true } },
-            options: ["", "\\.react"]
+            options: ["", "\\.react$"]
         }
     ],
 
@@ -285,9 +285,18 @@ ruleTester.run("lib/rules/match-exported with configuration", exportedRule, {
             code: exportedEs6JsxClassCode,
             filename: "/some/dir/Foo.bar.js",
             parserOptions: { ecmaVersion: 6, sourceType: "module", ecmaFeatures: { jsx: true } },
-            options: ["", "\\.react"],
+            options: ["", "\\.react$"],
             errors: [
                 { message: "Filename 'Foo.bar' must match the exported name 'Foo'.", column: 1, line: 1 }
+            ]
+        },
+        {
+            code: exportedEs6JsxClassCode,
+            filename: "/some/dir/Foo.react/index.js",
+            parserOptions: { ecmaVersion: 6, sourceType: "module", ecmaFeatures: { jsx: true } },
+            options: ["", "\\.react$"],
+            errors: [
+                { message: "The directory 'Foo.react' must be named 'Foo', after the exported value of its index file.", column: 1, line: 1 }
             ]
         }
     ]


### PR DESCRIPTION
This does two things:
- Adapt documentation and tests to only allow `.react` suffix not occurences of `.react` anywhere in the filename
- Disables replace pattern for directories, otherwise `Foo.react/index.js` would be valid.

@avaly @evgenyrodionov Can you have a look whether this looks fine to you as an adaption? I would like to adapt this before releasing a new version to npm.