### PR TITLE
add support for dot case

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ export default function variableName;
 Available transforms:
 '[snake](https://www.npmjs.com/package/lodash.snakecase)',
 '[kebab](https://www.npmjs.com/package/lodash.kebabcase)',
-'[camel](https://www.npmjs.com/package/lodash.camelcase)', and
-'pascal' (camel-cased with first letter in upper case).
+'[camel](https://www.npmjs.com/package/lodash.camelcase)',
+'pascal' (camel-cased with first letter in upper case), and
+'[dot](https://www.npmjs.com/package/dot-case)'.
 
 For multiple transforms simply specify an array like this (null in this case stands for no transform):
 

--- a/lib/rules/match-exported.js
+++ b/lib/rules/match-exported.js
@@ -20,7 +20,8 @@ var path = require('path'),
         camel: camelCase,
         pascal: function (name) {
             return upperFirst(camelCase(name));
-        }
+        },
+        dot: require('dot-case')
     },
     transformNames = Object.keys(transforms),
     transformSchema = { "enum": transformNames.concat([ null ]) };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "coveralls": "cat ./build/coverage/lcov.info | coveralls"
   },
   "dependencies": {
+    "dot-case": "2.1.1",
     "lodash.camelcase": "4.3.0",
     "lodash.kebabcase": "4.1.1",
     "lodash.snakecase": "4.1.1",


### PR DESCRIPTION
Hey

This PR adds support for dot case.
It covers our use case where we are using suffixes for store related stuff ie. `example.reducer.js` but we want our default export to contain suffix (ie. `exampleReducer`) instead of removing it.