### PR TITLE
#36: Feature Request: Do not apply match-exported if file is index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ Now, in your code:
 export default functionName();
 ```
 
+Finally, if you do not want the exports of an `index.js` to be compared against the parent directory, you can provide a fourth option (a boolean flag).
+
+```json
+"filenames/match-exported": [ 2, null, null, null, true ]
+```
+
+Now, in your code:
+
+```js
+// Considered problem only if file isn't named variableName.js. However, foo/index.js is fine.
+export default variableName;
+```
+
 ### Don't allow index.js files (no-index)
 
 Having a bunch of `index.js` files can have negative influence on developer experience, e.g. when

--- a/lib/rules/match-exported.js
+++ b/lib/rules/match-exported.js
@@ -74,7 +74,8 @@ module.exports = function(context) {
                 filename = context.getFilename(),
                 absoluteFilename = path.resolve(filename),
                 parsed = parseFilename(absoluteFilename),
-                shouldIgnore = isIgnoredFilename(filename),
+                shouldIgnoreIndexFiles = context.options[3] && isIndexFile(parsed),
+                shouldIgnore = isIgnoredFilename(filename) || shouldIgnoreIndexFiles,
                 exportedName = getExportedName(node, context.options),
                 isExporting = Boolean(exportedName),
                 expectedExport = getStringToCheckAgainstExport(parsed, replacePattern),
@@ -116,6 +117,9 @@ module.exports.schema = [
     },
     {
         type: [ "string", "null" ]
+    },
+    {
+        type: [ "boolean", "null" ]
     },
     {
         type: [ "boolean", "null" ]

--- a/test/rules/match-exported.js
+++ b/test/rules/match-exported.js
@@ -293,6 +293,11 @@ ruleTester.run("lib/rules/match-exported with configuration", exportedRule, {
             code: exportedCalledFunctionCode,
             filename: "/some/dir/foo.js",
             options: [null, null, true]
+        },
+        {
+            code: exportedVariableCode,
+            filename: "/some/dir/index.js",
+            options: [null, null, null, true] // directory need not match export from index.js
         }
     ],
 
@@ -366,6 +371,14 @@ ruleTester.run("lib/rules/match-exported with configuration", exportedRule, {
                 { message: "Filename 'bar' must match the exported name 'foo'.", column: 1, line: 1 }
             ],
             options: [null, null, true]
+        },
+        {
+            code: exportedVariableCode,
+            filename: "/some/dir/index.js",
+            errors: [
+                { message: "The directory 'dir' must be named 'exported', after the exported value of its index file.", column: 1, line: 1 }
+            ],
+            options: [null, null, null, false] // directory must match export from index.js
         }
     ]
 });


### PR DESCRIPTION
### Request
In issue 36, I wrote: 
> The organization I work for has a rule very similar to what match-exported provides, except that we do not want exports from an index.js file to need to match the directory name.
> We'd love to have something like another option to match-exported which would allow us to ask that it ignore index.js files.

### Offered Implementation
This PR include an implementation that addresses the request. It adds an additional option that, when set to true, will cause match-exported to ignore `index.js` files.