### PR TITLE
[chore] add ls-lint as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-filenames
 
-__This project is no longer actively maintained__
+__This project is no longer actively maintained. Please consider using [ls-lint](https://github.com/loeffel-io/ls-lint) as reliable alternative.__
 
 [![NPM Version](https://img.shields.io/npm/v/eslint-plugin-filenames.svg?style=flat-square)](https://www.npmjs.org/package/eslint-plugin-filenames)
 [![Build Status](https://img.shields.io/travis/selaux/eslint-plugin-filenames.svg?style=flat-square)](https://travis-ci.org/selaux/eslint-plugin-filenames)


### PR DESCRIPTION
Hey @selaux, 

it would be great to list [ls-lint](https://github.com/loeffel-io/ls-lint) as alternative since this repository is not maintained since 4 yours.

I could also add an migration guide if you want.

I think this would be really helpful for ls-lint and the community.

Best regards from Berlin to Berlin 😄 